### PR TITLE
検索ツール周りのスタイル調整

### DIFF
--- a/src/components/Explorer/DropdownContents.vue
+++ b/src/components/Explorer/DropdownContents.vue
@@ -65,13 +65,19 @@ export default defineComponent({
 .dropdownMenu {
   position: absolute;
   margin-top: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(33, 63, 99, 0.3);
+  z-index: 1;
+  background-color: #ffffff;
   .contents {
-    background-color: #ffffff;
-    box-shadow: 0.5rem 0rem 1rem -0.3rem rgba(10, 10, 10, 0.1);
-    border: solid 0.01rem #e7e7e7;
-    border-radius: 0.3;
     margin: 0;
-    padding: 1rem;
+    padding: 0.5rem 1rem;
+    &:first-child {
+      padding: 1rem 1rem 0.5rem;
+    }
+    &:last-child {
+      padding: 0.5rem 1rem 1rem;
+    }
     text-align: left;
     cursor: pointer;
     &:hover {

--- a/src/components/Explorer/DropdownMenu.vue
+++ b/src/components/Explorer/DropdownMenu.vue
@@ -72,17 +72,19 @@ export default defineComponent({
 <style lang="scss" module>
 .dropdownTrigger {
   display: flex;
-  padding: 0.3rem 1rem 0.3rem 1.4rem;
+  padding: 0.25rem 0.5rem 0.25rem 1rem;
   align-items: center;
   .title {
-    margin: 0 0.3rem 0 0;
+    margin: 0;
     font-size: 1rem;
+    width: 5rem;
+    text-align: left;
   }
 }
 .button {
   background-color: #ffffff;
   border: solid 0.1rem #cfb998;
-  border-radius: 0.3rem;
+  border-radius: 0.25rem;
   padding: 0;
   cursor: pointer;
   &:hover {

--- a/src/components/Explorer/Menus.vue
+++ b/src/components/Explorer/Menus.vue
@@ -4,7 +4,6 @@
       v-model="optionStr.sort"
       title="並べ替え"
       :contents="sortOrders"
-      :class="$style.dropdown"
       :is-open="state.isOpenSort"
       @open="openSort"
       @close="closeMenus"
@@ -14,7 +13,6 @@
       v-model="optionStr.nontargeted"
       title="フィルター"
       :contents="targetedOptions"
-      :class="$style.dropdown"
       :is-open="state.isOpenOption"
       @open="openOption"
       @close="closeMenus"
@@ -98,8 +96,6 @@ export default defineComponent({
 <style lang="scss" module>
 .container {
   display: flex;
-  .dropdown {
-    margin-right: 0.5rem;
-  }
+  column-gap: 1rem;
 }
 </style>

--- a/src/components/Explorer/SearchInput.vue
+++ b/src/components/Explorer/SearchInput.vue
@@ -1,15 +1,17 @@
 <template>
-  <input
-    type="text"
-    placeholder="検索"
-    :class="$style.input"
-    :value="modelValue"
-    @input="update"
-    @keypress.enter="search"
-  />
-  <button :class="[$style.button, $style.searchIcon]" @click="search">
-    <icon name="magnify" :class="$style.icon" />
-  </button>
+  <div :class="$style.container">
+    <input
+      type="text"
+      placeholder="検索"
+      :class="$style.input"
+      :value="modelValue"
+      @input="update"
+      @keypress.enter="search"
+    />
+    <button :class="[$style.button, $style.searchIcon]" @click="search">
+      <icon name="magnify" :class="$style.icon" />
+    </button>
+  </div>
 </template>
 
 <script lang="ts">
@@ -46,27 +48,36 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
+.container {
+  display: flex;
+  margin-right: auto;
+}
 .input {
-  border: solid 0.1rem #dbdbdb;
-  border-radius: 0.3rem 0 0 0.3rem;
-  padding-left: 0.8rem;
+  border: solid 0.1rem #cfb998;
+  border-right: none;
+  border-radius: 0.25rem 0 0 0.25rem;
+  width: 14rem;
+  padding-left: 1rem;
   &::placeholder {
-    color: #dbdbdb;
+    font-size: 1rem;
+    color: #a0a0a0;
   }
 }
 .searchIcon {
   display: flex;
   align-items: center;
-  border-radius: 0 0.3rem 0.3rem 0;
+  border-radius: 0 0.25rem 0.25rem 0;
   .icon {
     height: 1.25rem;
-    width: 1.25rem;
+    width: 1.5rem;
     padding: 0.3rem;
+    color: #ffffff;
   }
 }
 .button {
-  background-color: #ffffff;
-  border: solid 0.1rem #cfb998;
+  background-color: #92413b;
+  
+  border: solid 0.1rem #92413b;
   padding: 0;
   cursor: pointer;
   &:hover {

--- a/src/components/Explorer/SearchInput.vue
+++ b/src/components/Explorer/SearchInput.vue
@@ -76,7 +76,6 @@ export default defineComponent({
 }
 .button {
   background-color: #92413b;
-  
   border: solid 0.1rem #92413b;
   padding: 0;
   cursor: pointer;

--- a/src/pages/Explorer.vue
+++ b/src/pages/Explorer.vue
@@ -1,11 +1,11 @@
 <template>
   <div :class="$style.toolWrapper">
-    <menus @change="changeOption" />
     <search-input
       v-model="searchQuery"
       :class="$style.search"
       @search="search"
     />
+    <menus @change="changeOption" />
   </div>
   <div :class="$style.fadeExplorer">
     <transition name="fadeExplorer">
@@ -120,6 +120,7 @@ export default defineComponent({
   padding: 1rem 0rem;
   display: flex;
   flex-wrap: wrap;
+  row-gap: 1rem;
 }
 .container {
   box-sizing: border-box;


### PR DESCRIPTION
#656 に加えて検索ボックスのスタイルを調整しました。
`background-color`がきつい気がするのは文字色が黒なのも影響してそうなので #654 終わるまで保留したいです。


<img width="363" alt="image" src="https://user-images.githubusercontent.com/63178126/157464281-0fafa837-c53e-4f0b-a604-9f866f293f53.png">
<img width="881" alt="image" src="https://user-images.githubusercontent.com/63178126/157465644-12768f6b-7386-400a-9fd9-260a0c9e96f4.png">

