### PR TITLE
explore page へCardを適用

### DIFF
--- a/src/components/UI/Card.vue
+++ b/src/components/UI/Card.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="$style.container">
-    <div :class="$style.header">
+    <div v-show="headerVisible" :class="$style.header">
       <slot name="header"></slot>
     </div>
     <div :class="$style.content">
@@ -12,7 +12,13 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 export default defineComponent({
-  name: 'Card'
+  name: 'Card',
+  props: {
+    headerVisible: {
+      type: Boolean,
+      default: true
+    }
+  }
 })
 </script>
 

--- a/src/pages/Explorer.vue
+++ b/src/pages/Explorer.vue
@@ -8,34 +8,18 @@
       />
       <menus @change="changeOption" />
     </div>
-    <div :class="$style.fadeExplorer">
-      <transition name="fadeExplorer">
-        <div v-if="isFetched" :class="$style.container">
-          <ATable>
-            <template #tableheader>
-              <th
-                v-for="(header, index) in HEADERS"
-                :key="index"
-                :class="$style.header"
-              >
-                {{ header }}
-              </th>
-            </template>
-            <template #tablecontent>
-              <table-row
-                v-for="questionnaire in questionnaires"
-                :key="questionnaire.questionnaireID"
-              >
-                <questionnaires-table-row :questionnaire="questionnaire" />
-              </table-row>
-            </template>
-          </ATable>
-        </div>
-        <div v-else :class="$style.container">
-          <LoadingForExplorerAndResponses />
-        </div>
-      </transition>
-    </div>
+    <Card :header-visible="false">
+      <template #content>
+        <transition name="fadeTargeted">
+          <div v-if="isFetched">
+            <CardContentDetail :questionnaires="questionnaires" />
+          </div>
+          <div v-else>
+            <CardContentDetailMock />
+          </div>
+        </transition>
+      </template>
+    </Card>
   </div>
 </template>
 
@@ -44,24 +28,20 @@ import { defineComponent, onMounted, ref } from 'vue'
 import { useTitle } from './use/title'
 import Menus from '/@/components/Explorer/Menus.vue'
 import SearchInput from '/@/components/Explorer/SearchInput.vue'
-import QuestionnairesTableRow from '/@/components/Explorer/QuestionnairesTableRow.vue'
-import LoadingForExplorerAndResponses from '/@/components/UI/QuestionnairesTableMock.vue'
 import apis, { SortType, QuestionnaireForList } from '/@/lib/apis'
 import { Option } from '/@/components/Explorer/use/useOptions'
-import ATable from '/@/components/UI/ATable.vue'
-import TableRow from '/@/components/UI/TableRow.vue'
-
-const HEADERS = ['', '回答期限', '更新日時', '作成日時', '結果']
+import Card from '/@/components/UI/Card.vue'
+import CardContentDetail from '/@/components/UI/CardContentDetail.vue'
+import CardContentDetailMock from '/@/components/UI/CardContentDetailMock.vue'
 
 export default defineComponent({
   name: 'Explorer',
   components: {
-    ATable,
     Menus,
-    QuestionnairesTableRow,
     SearchInput,
-    TableRow,
-    LoadingForExplorerAndResponses
+    Card,
+    CardContentDetail,
+    CardContentDetailMock
   },
   setup() {
     useTitle(ref('アンケート一覧'))
@@ -106,7 +86,6 @@ export default defineComponent({
     })
 
     return {
-      HEADERS,
       questionnaires,
       searchQuery,
       changeOption,
@@ -136,22 +115,5 @@ export default defineComponent({
   position: absolute;
   width: 100%;
   max-width: 1280px;
-}
-.fadeExplorer {
-  position: relative;
-}
-.header {
-  text-align: center;
-  padding: 0.8rem;
-}
-:global {
-  .fadeExplorer-enter-active,
-  .fadeExplorer-leave-active {
-    transition: opacity 1s;
-  }
-  .fadeExplorer-enter-from,
-  .fadeExplorer-leave-to {
-    opacity: 0;
-  }
 }
 </style>

--- a/src/pages/Explorer.vue
+++ b/src/pages/Explorer.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="$style.pageWrapper">
-    <div :class="$style.toolWrapper">
+  <div :class="$style.page_wrapper">
+    <div :class="$style.tool_wrapper">
       <search-input
         v-model="searchQuery"
         :class="$style.search"
@@ -10,7 +10,7 @@
     </div>
     <Card :header-visible="false">
       <template #content>
-        <transition name="fadeTargeted">
+        <transition name="fadeExplore">
           <div v-if="isFetched">
             <CardContentDetail :questionnaires="questionnaires" />
           </div>
@@ -97,23 +97,23 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-.pageWrapper {
+.page_wrapper {
   max-width: 1280px;
 }
-.toolWrapper {
+.tool_wrapper {
   padding: 1rem 0rem;
   display: flex;
   flex-wrap: wrap;
   row-gap: 1rem;
 }
-.container {
-  box-sizing: border-box;
-  padding: 1rem;
-  border: solid 1.5px #d9d9d9;
-  overflow: auto;
-  top: 0;
-  position: absolute;
-  width: 100%;
-  max-width: 1280px;
+:global {
+  .fadeExplore-enter-active,
+  .fadeExplore-leave-active {
+    transition: opacity 0.2s;
+  }
+  .fadeExplore-enter-from,
+  .fadeExplore-leave-to {
+    opacity: 0;
+  }
 }
 </style>


### PR DESCRIPTION
src/pages/Explorer.vue へ src/components/UI/Card.vue を適用しました。

src/components/UI/Card.vue
- explorerでheaderが邪魔だったので、表示非表示を切り替えられるようにしました。

src/pages/Explorer.vue
- src/components/UI/Card.vue を使うようにしました
- 不要なclassの削除、名称の整理を行いました。